### PR TITLE
Update .bettercodehub.yml

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,6 +1,5 @@
 component_depth: 3
 languages:
-  - perl
   - name: perl
     production:
       include:


### PR DESCRIPTION
Hi Maurice

Your repos scores a 9 now !  tests are recognised
![Screenshot 2019-05-29 at 15 19 11](https://user-images.githubusercontent.com/18576001/58560298-2228a280-8225-11e9-91cb-67f775d34105.jpg)

I removed the extra line in the language list. I see know that we could have explained this better in our documentation. 

> To do so, replace a programming language name, like - java in the language list of the .bettercodehub.yml by the following structure:
